### PR TITLE
Add model evaluation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,6 @@ python evaluation/chat.py
 ```
 
 Type `quit` to exit. The demo prints the model's greedy completion of your
-prompt as plain text.
+prompt as plain text. The demo builds a token lookup table using frequencies from
+`vocab.json` so that the most common token is chosen when multiple tokens hash to
+the same ID.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,15 @@ python evaluation/eval_perplexity.py
 ```
 
 The script loads the checkpoint and validation file specified in `config.yaml` and prints the validation perplexity.
+
+## Chatting with the model
+
+You can run a simple interactive demo that predicts the next token for a line of
+text. Start the script and type your prompt:
+
+```bash
+python evaluation/chat.py
+```
+
+Type `quit` to exit. The demo prints the predicted token (and its numeric ID)
+using a greedy decode.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ prompt. Start the script and type your text:
 python evaluation/chat.py
 ```
 
-Type `quit` to exit. The demo prints the model's greedy completion of your
-prompt as plain text. The demo builds a token lookup table using frequencies from
-`vocab.json` so that the most common token is chosen when multiple tokens hash to
-the same ID.
+Type `quit` to exit. The demo now uses top-k sampling (k=3) instead of greedy
+decoding to produce a short sentence. It still builds a token lookup table using
+frequencies from `vocab.json` so that the most common token is chosen when
+multiple tokens hash to the same ID.

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ The script loads the checkpoint and validation file specified in `config.yaml` a
 
 ## Chatting with the model
 
-You can run a simple interactive demo that predicts the next token for a line of
-text. Start the script and type your prompt:
+You can run a simple interactive demo that generates a short sentence given your
+prompt. Start the script and type your text:
 
 ```bash
 python evaluation/chat.py
 ```
 
-Type `quit` to exit. The demo prints the predicted token (and its numeric ID)
-using a greedy decode.
+Type `quit` to exit. The demo prints the model's greedy completion of your
+prompt as plain text.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ Basic unit tests are located in `tests/`. Run them with:
 python -m unittest discover tests
 ```
 
+
+## Evaluating a trained model
+
+After training finishes, you can measure perplexity on the validation set using `evaluation/eval_perplexity.py`:
+
+```bash
+python evaluation/eval_perplexity.py
+```
+
+The script loads the checkpoint and validation file specified in `config.yaml` and prints the validation perplexity.

--- a/evaluation/chat.py
+++ b/evaluation/chat.py
@@ -11,10 +11,23 @@ from utils.functions import load_config
 CONFIG = load_config()
 
 def build_id_lookup(vocab_file, vocab_size):
+    """Return a mapping from hashed token ID to a representative token.
+
+    Because multiple tokens can map to the same hashed ID, we pick the most
+    frequent token for each ID based on the counts stored in ``vocab_file``.
+    ``vocab_file`` is expected to contain a JSON object mapping tokens to
+    frequency counts as produced by ``BPETokenizer``.
+    """
+
     with open(vocab_file, "r", encoding="utf-8") as f:
         vocab = json.load(f)
+
+    # Sort tokens by descending frequency to choose the most common token for
+    # each ID.  ``vocab`` maps token -> count.
+    sorted_tokens = sorted(vocab.items(), key=lambda kv: kv[1], reverse=True)
+
     table = {}
-    for token in vocab:
+    for token, _ in sorted_tokens:
         tid = hash(token) % vocab_size
         if tid not in table:
             table[tid] = token

--- a/evaluation/chat.py
+++ b/evaluation/chat.py
@@ -49,12 +49,16 @@ def load_model(device):
     model.eval()
     return model
 
-def predict_next(model, ids, device):
+def sample_next(model, ids, device, k=3, temperature=1.0):
+    """Return the next token ID using top-k sampling."""
     inp = torch.tensor([ids], dtype=torch.long).to(device)
     with torch.no_grad():
-        logits = model(inp)
-        next_id = torch.argmax(logits[0, -1]).item()
-    return next_id
+        logits = model(inp)[0, -1]
+        logits = logits / temperature
+        probs = torch.softmax(logits, dim=-1)
+        topk = torch.topk(probs, k)
+        choice = torch.multinomial(topk.values, 1).item()
+        return topk.indices[choice].item()
 
 def detokenize(tokens):
     words = []
@@ -69,7 +73,7 @@ def generate_sentence(model, ids, device, id_lookup, max_new_tokens=20):
     generated = []
     current = ids[:]
     for _ in range(max_new_tokens):
-        nxt = predict_next(model, current, device)
+        nxt = sample_next(model, current, device)
         token = id_lookup.get(nxt, "<UNK>")
         generated.append(token)
         current.append(nxt)

--- a/evaluation/chat.py
+++ b/evaluation/chat.py
@@ -43,6 +43,27 @@ def predict_next(model, ids, device):
         next_id = torch.argmax(logits[0, -1]).item()
     return next_id
 
+def detokenize(tokens):
+    words = []
+    for t in tokens:
+        if t.endswith("</w>"):
+            words.append(t[:-4])
+        else:
+            words.append(t)
+    return " ".join(words)
+
+def generate_sentence(model, ids, device, id_lookup, max_new_tokens=20):
+    generated = []
+    current = ids[:]
+    for _ in range(max_new_tokens):
+        nxt = predict_next(model, current, device)
+        token = id_lookup.get(nxt, "<UNK>")
+        generated.append(token)
+        current.append(nxt)
+        if token.endswith(".</w>") or token.endswith("?</w>") or token.endswith("!</w>"):
+            break
+    return detokenize(generated)
+
 def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     tokenizer = BPETokenizer()
@@ -61,9 +82,8 @@ def main():
         if not ids:
             print("Model: <no input>")
             continue
-        pred_id = predict_next(model, ids, device)
-        token = id_lookup.get(pred_id, "<UNK>")
-        print(f"Model: {token} (id {pred_id})")
+        sentence = generate_sentence(model, ids, device, id_lookup)
+        print(f"Model: {sentence}")
 
 if __name__ == "__main__":
     main()

--- a/evaluation/chat.py
+++ b/evaluation/chat.py
@@ -1,0 +1,69 @@
+import torch
+import json
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tokenizer.bpe_tokenizer import BPETokenizer
+from model.transformer import TransformerModel
+from utils.functions import load_config
+
+CONFIG = load_config()
+
+def build_id_lookup(vocab_file, vocab_size):
+    with open(vocab_file, "r", encoding="utf-8") as f:
+        vocab = json.load(f)
+    table = {}
+    for token in vocab:
+        tid = hash(token) % vocab_size
+        if tid not in table:
+            table[tid] = token
+    return table
+
+def load_model(device):
+    cfg = CONFIG.get("model", {})
+    model = TransformerModel(
+        vocab_size=CONFIG["vocab_size"],
+        embed_dim=cfg.get("embed_dim", 128),
+        num_heads=cfg.get("num_heads", 4),
+        ff_dim=cfg.get("ff_dim", 256),
+        num_layers=cfg.get("num_layers", 4),
+        max_len=cfg.get("max_len", 512),
+        dropout=cfg.get("dropout", 0.0),
+        positional_encoding=cfg.get("positional_encoding", "learned"),
+    ).to(device)
+    model.load_state_dict(torch.load(CONFIG["checkpoint_path"], map_location=device))
+    model.eval()
+    return model
+
+def predict_next(model, ids, device):
+    inp = torch.tensor([ids], dtype=torch.long).to(device)
+    with torch.no_grad():
+        logits = model(inp)
+        next_id = torch.argmax(logits[0, -1]).item()
+    return next_id
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tokenizer = BPETokenizer()
+    tokenizer.load_vocab(CONFIG["vocab_file"])
+    id_lookup = build_id_lookup(CONFIG["vocab_file"], CONFIG["vocab_size"])
+    model = load_model(device)
+
+    print("Type 'quit' to exit.")
+    while True:
+        text = input("You: ")
+        if text.lower() in {"quit", "exit"}:
+            break
+        tokens = tokenizer.tokenize(text)
+        flat = [t for sub in tokens for t in sub]
+        ids = [hash(t) % CONFIG["vocab_size"] for t in flat]
+        if not ids:
+            print("Model: <no input>")
+            continue
+        pred_id = predict_next(model, ids, device)
+        token = id_lookup.get(pred_id, "<UNK>")
+        print(f"Model: {token} (id {pred_id})")
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/eval_perplexity.py
+++ b/evaluation/eval_perplexity.py
@@ -1,0 +1,74 @@
+import torch
+from torch.utils.data import DataLoader, Dataset
+from torch import nn
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from tokenizer.bpe_tokenizer import BPETokenizer
+from model.transformer import TransformerModel
+from utils.functions import load_config
+
+CONFIG = load_config()
+
+class TextDataset(Dataset):
+    def __init__(self, file_path, tokenizer):
+        with open(file_path, "r", encoding="utf-8") as f:
+            self.lines = [line.strip() for line in f if line.strip()]
+        self.tokenizer = tokenizer
+
+    def __len__(self):
+        return len(self.lines)
+
+    def __getitem__(self, idx):
+        tokens = self.tokenizer.tokenize(self.lines[idx])
+        flat = [tok for sublist in tokens for tok in sublist]
+        ids = [hash(t) % CONFIG["vocab_size"] for t in flat]
+        return torch.tensor(ids, dtype=torch.long)
+
+def collate_fn(batch):
+    batch = [b for b in batch if len(b) > 1]
+    max_len = CONFIG["model"]["max_len"]
+    batch = [b[:max_len] for b in batch]
+    padded = [torch.cat([b, torch.zeros(max_len - len(b), dtype=torch.long)]) for b in batch]
+    return torch.stack(padded)
+
+def evaluate(model, loader, criterion, device):
+    model.eval()
+    total_loss, total_tokens = 0, 0
+    with torch.no_grad():
+        for batch in loader:
+            batch = batch.to(device)
+            inputs = batch[:, :-1]
+            targets = batch[:, 1:]
+            logits = model(inputs)
+            logits = logits.view(-1, logits.size(-1))
+            targets = targets.contiguous().view(-1)
+            loss = criterion(logits, targets)
+            total_loss += loss.item() * targets.size(0)
+            total_tokens += targets.size(0)
+    return torch.exp(torch.tensor(total_loss / total_tokens)).item()
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tokenizer = BPETokenizer()
+    tokenizer.load_vocab(CONFIG["vocab_file"])
+    data = TextDataset(CONFIG["val_file"], tokenizer)
+    loader = DataLoader(data, batch_size=CONFIG["batch_size"], shuffle=False, collate_fn=collate_fn)
+    model_cfg = CONFIG.get("model", {})
+    model = TransformerModel(
+        vocab_size=CONFIG["vocab_size"],
+        embed_dim=model_cfg.get("embed_dim", 128),
+        num_heads=model_cfg.get("num_heads", 4),
+        ff_dim=model_cfg.get("ff_dim", 256),
+        num_layers=model_cfg.get("num_layers", 4),
+        max_len=model_cfg.get("max_len", 512),
+        dropout=model_cfg.get("dropout", 0.0),
+        positional_encoding=model_cfg.get("positional_encoding", "learned"),
+    ).to(device)
+    model.load_state_dict(torch.load(CONFIG["checkpoint_path"], map_location=device))
+    criterion = nn.CrossEntropyLoss()
+    ppl = evaluate(model, loader, criterion, device)
+    print(f"Validation perplexity: {ppl:.2f}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script to compute validation perplexity
- document evaluation step in README

## Testing
- `python -m unittest discover tests` *(fails: cannot load torch)*

------
https://chatgpt.com/codex/tasks/task_e_68566d4280908320bc76f24331ce19e7